### PR TITLE
Replaced LastModified with the UpdatedAt date from metadata

### DIFF
--- a/Source/ReadyPlayerMe/Private/ReadyPlayerMeAvatarLoader.cpp
+++ b/Source/ReadyPlayerMe/Private/ReadyPlayerMeAvatarLoader.cpp
@@ -13,8 +13,6 @@
 constexpr float AVATAR_REQUEST_TIMEOUT = 60.f;
 constexpr float METADATA_REQUEST_TIMEOUT = 20.f;
 
-static const FString HEADER_LAST_MODIFIED = "Last-Modified";
-
 UReadyPlayerMeAvatarLoader::UReadyPlayerMeAvatarLoader()
 	: SkeletalMesh(nullptr)
 	, GlbLoader(nullptr)
@@ -70,8 +68,7 @@ void UReadyPlayerMeAvatarLoader::CancelAvatarLoad()
 void UReadyPlayerMeAvatarLoader::ProcessReceivedMetadata()
 {
 	AvatarMetadata = FReadyPlayerMeMetadataExtractor::ExtractAvatarMetadata(MetadataRequest->GetContentAsString());
-	AvatarMetadata->LastModifiedDate = MetadataRequest->GetHeader(HEADER_LAST_MODIFIED);
-	CacheHandler->SetUpdatedMetadataStr(MetadataRequest->GetContentAsString(), AvatarMetadata->LastModifiedDate);
+	CacheHandler->SetUpdatedMetadataStr(MetadataRequest->GetContentAsString(), AvatarMetadata->UpdatedAtDate);
 	// If we are not trying to update the avatar, the metadata and the model should be downloaded as the standard flow.
 	if (!bIsTryingToUpdate)
 	{

--- a/Source/ReadyPlayerMe/Private/Request/ReadyPlayerMeBaseRequest.cpp
+++ b/Source/ReadyPlayerMe/Private/Request/ReadyPlayerMeBaseRequest.cpp
@@ -62,8 +62,3 @@ FString FReadyPlayerMeBaseRequest::GetContentAsString() const
 {
 	return DownloadRequest->GetResponse()->GetContentAsString();
 }
-
-FString FReadyPlayerMeBaseRequest::GetHeader(const FString& Header) const
-{
-	return DownloadRequest->GetResponse()->GetHeader(Header);
-}

--- a/Source/ReadyPlayerMe/Private/Request/ReadyPlayerMeBaseRequest.h
+++ b/Source/ReadyPlayerMe/Private/Request/ReadyPlayerMeBaseRequest.h
@@ -20,8 +20,6 @@ public:
 	
 	FString GetContentAsString() const;
 
-	FString GetHeader(const FString& Header) const;
-
 private:
 	void OnReceived(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess);
 

--- a/Source/ReadyPlayerMe/Private/Storage/ReadyPlayerMeAvatarCacheHandler.cpp
+++ b/Source/ReadyPlayerMe/Private/Storage/ReadyPlayerMeAvatarCacheHandler.cpp
@@ -29,7 +29,7 @@ bool FReadyPlayerMeAvatarCacheHandler::ShouldLoadFromCache() const
 	return IsCachingEnabled() && FReadyPlayerMeAvatarStorage::AvatarExists(AvatarUri);
 }
 
-bool FReadyPlayerMeAvatarCacheHandler::IsMetadataChanged(const FString& UpdatedDate) const
+bool FReadyPlayerMeAvatarCacheHandler::IsMedataUpdated(const FString& UpdatedDate) const
 {
 	const auto Metadata = GetLocalMetadata();
 	if (Metadata.IsSet())
@@ -60,7 +60,7 @@ void FReadyPlayerMeAvatarCacheHandler::SetUpdatedMetadataStr(const FString& Meta
 	{
 		return;
 	}
-	bMetadataNeedsUpdate = IsMetadataChanged(UpdatedDate);
+	bMetadataNeedsUpdate = IsMedataUpdated(UpdatedDate);
 	UpdatedMetadataStr = MetadataJson;
 	if (FReadyPlayerMeAvatarStorage::FileExists(AvatarUri.LocalMetadataPath) && bMetadataNeedsUpdate)
 	{

--- a/Source/ReadyPlayerMe/Private/Storage/ReadyPlayerMeAvatarCacheHandler.cpp
+++ b/Source/ReadyPlayerMe/Private/Storage/ReadyPlayerMeAvatarCacheHandler.cpp
@@ -29,12 +29,12 @@ bool FReadyPlayerMeAvatarCacheHandler::ShouldLoadFromCache() const
 	return IsCachingEnabled() && FReadyPlayerMeAvatarStorage::AvatarExists(AvatarUri);
 }
 
-bool FReadyPlayerMeAvatarCacheHandler::IsMetadataChanged(const FString& LastModifiedDate) const
+bool FReadyPlayerMeAvatarCacheHandler::IsMetadataChanged(const FString& UpdatedDate) const
 {
 	const auto Metadata = GetLocalMetadata();
 	if (Metadata.IsSet())
 	{
-		return Metadata->LastModifiedDate != LastModifiedDate;
+		return Metadata->UpdatedAtDate != UpdatedDate;
 	}
 	return true;
 }
@@ -54,14 +54,14 @@ bool FReadyPlayerMeAvatarCacheHandler::ShouldSaveMetadata() const
 	return bMetadataNeedsUpdate;
 }
 
-void FReadyPlayerMeAvatarCacheHandler::SetUpdatedMetadataStr(const FString& MetadataJson, const FString& LastModifiedDate)
+void FReadyPlayerMeAvatarCacheHandler::SetUpdatedMetadataStr(const FString& MetadataJson, const FString& UpdatedDate)
 {
 	if (!IsCachingEnabled())
 	{
 		return;
 	}
-	bMetadataNeedsUpdate = IsMetadataChanged(LastModifiedDate);
-	UpdatedMetadataStr = FReadyPlayerMeMetadataExtractor::AddModifiedDateToMetadataJson(MetadataJson, LastModifiedDate);
+	bMetadataNeedsUpdate = IsMetadataChanged(UpdatedDate);
+	UpdatedMetadataStr = MetadataJson;
 	if (FReadyPlayerMeAvatarStorage::FileExists(AvatarUri.LocalMetadataPath) && bMetadataNeedsUpdate)
 	{
 		FReadyPlayerMeAvatarStorage::DeleteDirectory(AvatarUri.LocalAvatarDirectory);

--- a/Source/ReadyPlayerMe/Private/Storage/ReadyPlayerMeAvatarCacheHandler.h
+++ b/Source/ReadyPlayerMe/Private/Storage/ReadyPlayerMeAvatarCacheHandler.h
@@ -10,7 +10,7 @@ class FReadyPlayerMeAvatarCacheHandler
 public:
 	explicit FReadyPlayerMeAvatarCacheHandler(const FAvatarUri& AvatarUri);
 
-	void SetUpdatedMetadataStr(const FString& MetadataJson, const FString& LastModifiedDate);
+	void SetUpdatedMetadataStr(const FString& MetadataJson, const FString& UpdatedDate);
 	void SetModelData(const TArray<uint8>* Data);
 
 	void SaveAvatarInCache() const;
@@ -24,7 +24,7 @@ public:
 	static bool IsCachingEnabled();
 
 private:
-	bool IsMetadataChanged(const FString& LastModifiedDate) const;
+	bool IsMetadataChanged(const FString& UpdatedDate) const;
 	
 	const FAvatarUri AvatarUri;
 

--- a/Source/ReadyPlayerMe/Private/Storage/ReadyPlayerMeAvatarCacheHandler.h
+++ b/Source/ReadyPlayerMe/Private/Storage/ReadyPlayerMeAvatarCacheHandler.h
@@ -24,7 +24,7 @@ public:
 	static bool IsCachingEnabled();
 
 private:
-	bool IsMetadataChanged(const FString& UpdatedDate) const;
+	bool IsMedataUpdated(const FString& UpdatedDate) const;
 	
 	const FAvatarUri AvatarUri;
 

--- a/Source/ReadyPlayerMe/Private/Utils/ReadyPlayerMeMetadataExtractor.cpp
+++ b/Source/ReadyPlayerMe/Private/Utils/ReadyPlayerMeMetadataExtractor.cpp
@@ -18,7 +18,7 @@ static const FString TYPE_HALFBODY = "Halfbody";
 static const FString JSON_FIELD_OUTFIT = "outfitVersion";
 static const FString JSON_FIELD_BODY = "bodyType";
 static const FString JSON_FIELD_GENDER = "outfitGender";
-static const FString JSON_FIELD_MODIFIED_DATE = "lastModifiedDate";
+static const FString JSON_FIELD_UPDATED_AT = "updatedAt";
 static const int MAX_HALFBODY_NODES=60;
 
 FString FReadyPlayerMeMetadataExtractor::GetRootBoneName(const EAvatarBodyType& AvatarBodyType)
@@ -43,24 +43,6 @@ EAvatarBodyType FReadyPlayerMeMetadataExtractor::GetBodyTypeFromAsset(UglTFRunti
 	return EAvatarBodyType::HalfBody;
 }
 
-FString FReadyPlayerMeMetadataExtractor::AddModifiedDateToMetadataJson(const FString& JsonString, const FString& LastModifiedDate)
-{
-	FString OutputJsonString;
-	TSharedPtr<FJsonObject> JsonObject;
-	const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
-	if (FJsonSerializer::Deserialize(Reader, JsonObject))
-	{
-		JsonObject->SetStringField(JSON_FIELD_MODIFIED_DATE, LastModifiedDate);
-
-		const auto Writer = TJsonWriterFactory<>::Create(&OutputJsonString);
-		if (!FJsonSerializer::Serialize(JsonObject.ToSharedRef(), Writer))
-		{
-			UE_LOG(LogReadyPlayerMe, Warning, TEXT("Failed to create a valid url"));
-		}
-	}
-	return OutputJsonString;
-}
-
 FAvatarMetadata FReadyPlayerMeMetadataExtractor::ExtractAvatarMetadata(const FString& JsonString)
 {
 	TSharedPtr<FJsonObject> JsonObject;
@@ -70,9 +52,9 @@ FAvatarMetadata FReadyPlayerMeMetadataExtractor::ExtractAvatarMetadata(const FSt
 
 	if (FJsonSerializer::Deserialize(Reader, JsonObject))
 	{
-		if (JsonObject->HasField(JSON_FIELD_MODIFIED_DATE))
+		if (JsonObject->HasField(JSON_FIELD_UPDATED_AT))
 		{
-			Metadata.LastModifiedDate = JsonObject->GetStringField(JSON_FIELD_MODIFIED_DATE);
+			Metadata.UpdatedAtDate = JsonObject->GetStringField(JSON_FIELD_UPDATED_AT);
 		}
 		if (JsonObject->HasField(JSON_FIELD_BODY))
 		{

--- a/Source/ReadyPlayerMe/Private/Utils/ReadyPlayerMeMetadataExtractor.h
+++ b/Source/ReadyPlayerMe/Private/Utils/ReadyPlayerMeMetadataExtractor.h
@@ -13,6 +13,4 @@ public:
 	static EAvatarBodyType GetBodyTypeFromAsset(class UglTFRuntimeAsset* GltfRuntimeAsset);
 
 	static FAvatarMetadata ExtractAvatarMetadata(const FString& JsonString);
-
-	static FString AddModifiedDateToMetadataJson(const FString& JsonString, const FString& LastModifiedDate);
 };

--- a/Source/ReadyPlayerMe/Public/ReadyPlayerMeTypes.h
+++ b/Source/ReadyPlayerMe/Public/ReadyPlayerMeTypes.h
@@ -34,7 +34,7 @@ struct FAvatarMetadata
 	int32 OutfitVersion;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ReadyPlayerMe")
-	FString LastModifiedDate;
+	FString UpdatedAtDate;
 
 	FAvatarMetadata()
 	{


### PR DESCRIPTION
## [4129833511](https://ready-player-me.monday.com/boards/2563815861/pulses/4129833511)

## Description

-   Replaced LastModified with the UpdatedAt date from metadata

## Changes

#### Updated

-   Replaced LastModified with the UpdatedAt date from metadata

<!-- Testability -->

## How to Test

-   Caching should work in both previews and current implementation. When switching from the previews to the current implementation the existing cached avatars will be downloaded.

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
