### PR TITLE
Added meshOpt param to the avatar config

### DIFF
--- a/Source/ReadyPlayerMe/Private/Utils/ReadyPlayerMeAvatarConfigProcessor.cpp
+++ b/Source/ReadyPlayerMe/Private/Utils/ReadyPlayerMeAvatarConfigProcessor.cpp
@@ -97,6 +97,7 @@ FString FReadyPlayerMeAvatarConfigProcessor::Process(UReadyPlayerMeAvatarConfig*
 	Parameters.Add("textureChannels=" + ProcessTextureChannels(AvatarConfig->TextureChannels));
 	Parameters.Add(ProcessMorphTargets(AvatarConfig->MorphTargetGroup));
 	Parameters.Add("useHands=" + UKismetStringLibrary::Conv_BoolToString(AvatarConfig->bUseHands));
+	Parameters.Add("meshOptCompression=" + UKismetStringLibrary::Conv_BoolToString(AvatarConfig->bMeshOptCompression));
 	Parameters.Add("useDracoMeshCompression=" + UKismetStringLibrary::Conv_BoolToString(UseDraco));
 	return "?" + FString::Join(Parameters, TEXT("&"));
 }

--- a/Source/ReadyPlayerMe/Public/AvatarConfig/ReadyPlayerMeAvatarConfig.h
+++ b/Source/ReadyPlayerMe/Public/AvatarConfig/ReadyPlayerMeAvatarConfig.h
@@ -89,8 +89,18 @@ public:
 	bool bUseHands = true;
 
 	/**
+	 * If set to true the avatar will be compressed with the Mesh-Opt compression.
+	 * Mesh-Opt compression will effectively reduce the size of the avatar by compressing the mesh geometry.
+	 *
+	 * @note Mesh-Opt compression should not be used along with the Draco compression.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Ready Player Me")
+	bool bMeshOptCompression = false;
+
+	/**
 	 * If set to true the avatar will be compressed with the Draco mesh compression.
 	 *
+	 * @note prefer using Mesh-Opt compression instead.
 	 * @note If the glTFRuntimeDraco plugin is not listed as a project dependency, this property will be ignored.
 	 */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Ready Player Me")


### PR DESCRIPTION
## [TICKETID](https://ready-player-me.monday.com/boards/2563815861/pulses/TICKETID)

## Description

-   Added meshOpt param to the avatar config

## Changes

#### Added

-   Added meshOpt param to the avatar config

## How to Test

-   set the meshopt compression in the avatar config that is included in the SDK and run the demo map.

## Checklist

-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

