### PR TITLE
SDK-263 feat: replaces meshLod property with lod

### DIFF
--- a/Source/ReadyPlayerMe/Private/Utils/ReadyPlayerMeAvatarConfigProcessor.cpp
+++ b/Source/ReadyPlayerMe/Private/Utils/ReadyPlayerMeAvatarConfigProcessor.cpp
@@ -91,7 +91,7 @@ FString FReadyPlayerMeAvatarConfigProcessor::Process(UReadyPlayerMeAvatarConfig*
 	const bool UseDraco = FReadyPlayerMePluginInfo::IsDracoPluginIncluded() && AvatarConfig->bUseDracoMeshCompression;
 	TArray<FString> Parameters;
 	Parameters.Add("pose=" + POSE_TO_STRING[AvatarConfig->Pose]);
-	Parameters.Add("meshLod=" + FString::FromInt(static_cast<int>(AvatarConfig->MeshLod)));
+	Parameters.Add("lod=" + FString::FromInt(static_cast<int>(AvatarConfig->MeshLod)));
 	Parameters.Add("textureAtlas=" + TEXTURE_ATLAS_TO_STRING[AvatarConfig->TextureAtlas]);
 	Parameters.Add("textureSizeLimit=" + TEXTURE_SIZE_LIMIT_TO_STRING[AvatarConfig->TextureSizeLimit]);
 	Parameters.Add("textureChannels=" + ProcessTextureChannels(AvatarConfig->TextureChannels));


### PR DESCRIPTION
SDK-263

me.atlassian.net/jira/software/c/projects/SDK/boards/6?modal=detail&selectedIssue=SDK-263)

## Description

Replace meshLod property with lod property when requesting from the Ready Player Me API.