### PR TITLE
[SDK-372] Automated Cache Management for Unreal

### DIFF
--- a/Source/ReadyPlayerMe/Private/ReadyPlayerMeFunctionLibrary.cpp
+++ b/Source/ReadyPlayerMe/Private/ReadyPlayerMeFunctionLibrary.cpp
@@ -2,17 +2,27 @@
 
 
 #include "ReadyPlayerMeFunctionLibrary.h"
+
+#include "ReadyPlayerMeGameSubsystem.h"
+#include "Kismet/GameplayStatics.h"
+#include "Storage/AvatarManifest.h"
 #include "Storage/AvatarStorage.h"
 #include "Utils/AvatarUrlConvertor.h"
 
-void UReadyPlayerMeFunctionLibrary::ClearAvatarCache()
+void UReadyPlayerMeFunctionLibrary::ClearAvatarCache(const UObject* WorldContextObject)
 {
 	FAvatarStorage::ClearCache();
+    const UGameInstance* GameInstance = UGameplayStatics::GetGameInstance(WorldContextObject);
+    const UReadyPlayerMeGameSubsystem* GameSubsystem = UGameInstance::GetSubsystem<UReadyPlayerMeGameSubsystem>(GameInstance);
+    GameSubsystem->AvatarManifest->Clear();
 }
 
-void UReadyPlayerMeFunctionLibrary::ClearAvatar(const FString& Guid)
+void UReadyPlayerMeFunctionLibrary::ClearAvatar(const UObject* WorldContextObject, const FString& AvatarId)
 {
-    FAvatarStorage::ClearAvatar(Guid);
+    FAvatarStorage::ClearAvatar(AvatarId);
+    const UGameInstance* GameInstance = UGameplayStatics::GetGameInstance(WorldContextObject);
+    const UReadyPlayerMeGameSubsystem* GameSubsystem = UGameInstance::GetSubsystem<UReadyPlayerMeGameSubsystem>(GameInstance);
+    GameSubsystem->AvatarManifest->RemoveAvatar(AvatarId);
 }
 
 bool UReadyPlayerMeFunctionLibrary::IsAvatarCacheEmpty()
@@ -22,7 +32,7 @@ bool UReadyPlayerMeFunctionLibrary::IsAvatarCacheEmpty()
 
 int32 UReadyPlayerMeFunctionLibrary::GetAvatarCount()
 {
-    return FAvatarStorage::GetAvatarCount();
+    return FAvatarStorage::GetSavedAvatars().Num();
 }
 
 int64 UReadyPlayerMeFunctionLibrary::GetCacheSize()

--- a/Source/ReadyPlayerMe/Private/ReadyPlayerMeFunctionLibrary.cpp
+++ b/Source/ReadyPlayerMe/Private/ReadyPlayerMeFunctionLibrary.cpp
@@ -22,7 +22,7 @@ void UReadyPlayerMeFunctionLibrary::ClearAvatarFromCache(const UObject* WorldCon
     FAvatarStorage::ClearAvatar(AvatarId);
     const UGameInstance* GameInstance = UGameplayStatics::GetGameInstance(WorldContextObject);
     const UReadyPlayerMeGameSubsystem* GameSubsystem = UGameInstance::GetSubsystem<UReadyPlayerMeGameSubsystem>(GameInstance);
-    GameSubsystem->AvatarManifest->RemoveAvatar(AvatarId);
+    GameSubsystem->AvatarManifest->ClearAvatar(AvatarId);
 }
 
 bool UReadyPlayerMeFunctionLibrary::IsAvatarCacheEmpty()

--- a/Source/ReadyPlayerMe/Private/ReadyPlayerMeFunctionLibrary.cpp
+++ b/Source/ReadyPlayerMe/Private/ReadyPlayerMeFunctionLibrary.cpp
@@ -40,7 +40,7 @@ int64 UReadyPlayerMeFunctionLibrary::GetCacheSize()
     return FAvatarStorage::GetCacheSize();
 }
 
-FString UReadyPlayerMeFunctionLibrary::GetAvatarGuid(const FString& UrlShortcode)
+FString UReadyPlayerMeFunctionLibrary::GetAvatarId(const FString& Url)
 {
-    return FAvatarUrlConvertor::GetAvatarId(UrlShortcode);
+    return FAvatarUrlConvertor::GetAvatarId(Url);
 }

--- a/Source/ReadyPlayerMe/Private/ReadyPlayerMeFunctionLibrary.cpp
+++ b/Source/ReadyPlayerMe/Private/ReadyPlayerMeFunctionLibrary.cpp
@@ -17,7 +17,7 @@ void UReadyPlayerMeFunctionLibrary::ClearAvatarCache(const UObject* WorldContext
     GameSubsystem->AvatarManifest->Clear();
 }
 
-void UReadyPlayerMeFunctionLibrary::ClearAvatar(const UObject* WorldContextObject, const FString& AvatarId)
+void UReadyPlayerMeFunctionLibrary::ClearAvatarFromCache(const UObject* WorldContextObject, const FString& AvatarId)
 {
     FAvatarStorage::ClearAvatar(AvatarId);
     const UGameInstance* GameInstance = UGameplayStatics::GetGameInstance(WorldContextObject);
@@ -30,12 +30,12 @@ bool UReadyPlayerMeFunctionLibrary::IsAvatarCacheEmpty()
     return FAvatarStorage::IsCacheEmpty();
 }
 
-int32 UReadyPlayerMeFunctionLibrary::GetAvatarCount()
+int32 UReadyPlayerMeFunctionLibrary::GetCachedAvatarCount()
 {
     return FAvatarStorage::GetSavedAvatars().Num();
 }
 
-int64 UReadyPlayerMeFunctionLibrary::GetCacheSize()
+int64 UReadyPlayerMeFunctionLibrary::GetAvatarCacheSize()
 {
     return FAvatarStorage::GetCacheSize();
 }

--- a/Source/ReadyPlayerMe/Private/ReadyPlayerMeGameSubsystem.cpp
+++ b/Source/ReadyPlayerMe/Private/ReadyPlayerMeGameSubsystem.cpp
@@ -3,16 +3,21 @@
 #include "ReadyPlayerMeGameSubsystem.h"
 #include "ReadyPlayerMeMemoryCache.h"
 
+#include "Storage/AvatarManifest.h"
+
 UReadyPlayerMeGameSubsystem::UReadyPlayerMeGameSubsystem()
 	: MemoryCache(nullptr)
+	, AvatarManifest(nullptr)
 {}
 
 void UReadyPlayerMeGameSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
 	MemoryCache = NewObject<UReadyPlayerMeMemoryCache>(this, TEXT("MemoryCache"));
+	AvatarManifest = MakeShared<FAvatarManifest>();
 }
 
 void UReadyPlayerMeGameSubsystem::Deinitialize()
 {
 	MemoryCache = nullptr;
+	AvatarManifest.Reset();
 }

--- a/Source/ReadyPlayerMe/Private/ReadyPlayerMeSettings.cpp
+++ b/Source/ReadyPlayerMe/Private/ReadyPlayerMeSettings.cpp
@@ -4,6 +4,7 @@
 
 UReadyPlayerMeSettings::UReadyPlayerMeSettings()
 	: bEnableAvatarCaching(false)
+	, CachedAvatarLimit(50)
 {
 }
 

--- a/Source/ReadyPlayerMe/Private/ReadyPlayerMeSettings.cpp
+++ b/Source/ReadyPlayerMe/Private/ReadyPlayerMeSettings.cpp
@@ -3,8 +3,6 @@
 #include "ReadyPlayerMeSettings.h"
 
 UReadyPlayerMeSettings::UReadyPlayerMeSettings()
-	: bEnableAvatarCaching(false)
-	, CachedAvatarLimit(50)
 {
 }
 
@@ -13,7 +11,7 @@ void UReadyPlayerMeSettings::SetAvatarCaching(bool bEnableCaching)
 	UReadyPlayerMeSettings* Settings = GetMutableDefault<UReadyPlayerMeSettings>();
 	if (Settings)
 	{
-		Settings->bEnableAvatarCaching = bEnableCaching;
+		Settings->AvatarCacheSettings.bEnableAvatarCaching = bEnableCaching;
 		Settings->SaveConfig();
 	}
 }

--- a/Source/ReadyPlayerMe/Private/Storage/AvatarCacheHandler.cpp
+++ b/Source/ReadyPlayerMe/Private/Storage/AvatarCacheHandler.cpp
@@ -28,7 +28,7 @@ FAvatarCacheHandler::FAvatarCacheHandler(const FAvatarUri& AvatarUri, TSharedPtr
 {
 	if (AvatarCacheSettings.bEnableAvatarCaching && AvatarCacheSettings.bEnableAutomaticCacheCleaning && AvatarManifest.IsValid())
 	{
-		AvatarManifest->BlockAvatar(AvatarUri.Guid);
+		AvatarManifest->LockAvatar(AvatarUri.Guid);
 	}
 }
 
@@ -36,7 +36,7 @@ FAvatarCacheHandler::~FAvatarCacheHandler()
 {
 	if (AvatarCacheSettings.bEnableAvatarCaching && AvatarCacheSettings.bEnableAutomaticCacheCleaning && AvatarManifest.IsValid())
 	{
-		AvatarManifest->UnblockAvatar(AvatarUri.Guid);
+		AvatarManifest->UnlockAvatar(AvatarUri.Guid);
 	}
 }
 

--- a/Source/ReadyPlayerMe/Private/Storage/AvatarCacheHandler.cpp
+++ b/Source/ReadyPlayerMe/Private/Storage/AvatarCacheHandler.cpp
@@ -27,7 +27,7 @@ FAvatarCacheHandler::FAvatarCacheHandler(const FAvatarUri& AvatarUri, TSharedPtr
 	, AvatarManifest(MoveTemp(Manifest))
 	, bIsCachingEnabled(IsCachingEnabled() && AvatarManifest.IsValid())
 {
-	if (!bIsCachingEnabled)
+	if (bIsCachingEnabled)
 	{
 		AvatarManifest->BlockAvatar(AvatarUri.Guid);
 	}
@@ -35,7 +35,7 @@ FAvatarCacheHandler::FAvatarCacheHandler(const FAvatarUri& AvatarUri, TSharedPtr
 
 FAvatarCacheHandler::~FAvatarCacheHandler()
 {
-	if (!bIsCachingEnabled)
+	if (bIsCachingEnabled)
 	{
 		AvatarManifest->UnblockAvatar(AvatarUri.Guid);
 	}

--- a/Source/ReadyPlayerMe/Private/Storage/AvatarCacheHandler.h
+++ b/Source/ReadyPlayerMe/Private/Storage/AvatarCacheHandler.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "ReadyPlayerMeSettings.h"
 #include "ReadyPlayerMeTypes.h"
 
 class FAvatarCacheHandler
@@ -34,5 +35,5 @@ private:
 	bool bMetadataNeedsUpdate;
 
 	TSharedPtr<class FAvatarManifest> AvatarManifest;
-	const bool bIsCachingEnabled;
+	const FRpmAvatarCacheSettings AvatarCacheSettings;
 };

--- a/Source/ReadyPlayerMe/Private/Storage/AvatarCacheHandler.h
+++ b/Source/ReadyPlayerMe/Private/Storage/AvatarCacheHandler.h
@@ -8,20 +8,21 @@
 class FAvatarCacheHandler
 {
 public:
-	explicit FAvatarCacheHandler(const FAvatarUri& AvatarUri);
+	FAvatarCacheHandler(const FAvatarUri& AvatarUri, TSharedPtr<class FAvatarManifest> Manifest);
+	~FAvatarCacheHandler();
 
 	void SetUpdatedMetadataStr(const FString& MetadataJson, const FString& UpdatedDate);
 	void SetModelData(const TArray<uint8>* Data);
 
 	void SaveAvatarInCache() const;
 
+	void ResetState();
+
 	bool ShouldLoadFromCache() const;
 
 	bool ShouldSaveMetadata() const;
 	
 	TOptional<FAvatarMetadata> GetLocalMetadata() const;
-
-	static bool IsCachingEnabled();
 
 private:
 	bool IsMedataUpdated(const FString& UpdatedDate) const;
@@ -31,4 +32,7 @@ private:
 	FString UpdatedMetadataStr;
 	const TArray<uint8>* ModelData;
 	bool bMetadataNeedsUpdate;
+
+	TSharedPtr<class FAvatarManifest> AvatarManifest;
+	const bool bIsCachingEnabled;
 };

--- a/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.cpp
+++ b/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.cpp
@@ -7,13 +7,18 @@
 #include "Storage/AvatarStorage.h"
 #include "Utils/AvatarManifestExtractor.h"
 
+void FAvatarManifest::AddAvatarAndEnforceLimit(const FString& AvatarId)
+{
+	AddAvatar(AvatarId);
+	EnforceAvatarLimit();
+}
+
 void FAvatarManifest::AddAvatar(const FString& AvatarId)
 {
 	if (!AvatarRecords.Contains(AvatarId))
 	{
 		AvatarRecords.Add(AvatarId, FDateTime::Now().ToUnixTimestamp());
 	}
-	EnforceAvatarLimit();
 }
 
 void FAvatarManifest::BlockAvatar(const FString& AvatarId)
@@ -95,12 +100,12 @@ void FAvatarManifest::EnforceAvatarLimit()
 		Load();
 	}
 	int32 CurrentAvatarCount = AvatarRecords.Num();
-	if (CurrentAvatarCount <= Settings->CachedAvatarLimit)
+	if (CurrentAvatarCount <= Settings->AvatarCacheSettings.CachedAvatarLimit)
 	{
 		return;
 	}
 	TArray<FString> AvatarQueue = GetIdsByOldestDate();
-	while (CurrentAvatarCount > Settings->CachedAvatarLimit && AvatarQueue.Num() != 0)
+	while (CurrentAvatarCount > Settings->AvatarCacheSettings.CachedAvatarLimit && AvatarQueue.Num() != 0)
 	{
 		const FString AvatarId = AvatarQueue.Pop();
 		FAvatarStorage::ClearAvatar(AvatarId);

--- a/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.cpp
+++ b/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.cpp
@@ -1,0 +1,111 @@
+// Copyright © 2021++ Ready Player Me
+
+
+#include "AvatarManifest.h"
+
+#include "ReadyPlayerMeSettings.h"
+#include "Storage/AvatarStorage.h"
+#include "Utils/AvatarManifestExtractor.h"
+
+void FAvatarManifest::AddAvatar(const FString& AvatarId)
+{
+	if (!AvatarRecords.Contains(AvatarId))
+	{
+		AvatarRecords.Add(AvatarId, FDateTime::Now().ToUnixTimestamp());
+	}
+	EnforceAvatarLimit();
+}
+
+void FAvatarManifest::BlockAvatar(const FString& AvatarId)
+{
+	Load();
+	BlockedAvatars.Add(AvatarId);
+	if (AvatarRecords.Contains(AvatarId))
+	{
+		AvatarRecords[AvatarId] = FDateTime::Now().ToUnixTimestamp();
+		Save();
+	}
+}
+
+void FAvatarManifest::UnblockAvatar(const FString& AvatarId)
+{
+	BlockedAvatars.Remove(AvatarId);
+}
+
+void FAvatarManifest::RemoveAvatar(const FString& AvatarId)
+{
+	Load();
+	AvatarRecords.Remove(AvatarId);
+	Save();
+}
+
+void FAvatarManifest::Clear()
+{
+	Load();
+	AvatarRecords.Empty();
+	Save();
+}
+
+void FAvatarManifest::Load()
+{
+	if (bIsManifestLoaded)
+	{
+		return;
+	}
+	const FString ManifestFilename = FAvatarStorage::GetManifestFilePath();
+	if (!FAvatarStorage::FileExists(ManifestFilename))
+	{
+		const TArray<FString> SavedAvatars = FAvatarStorage::GetSavedAvatars();
+		for (const auto& AvatarId : SavedAvatars)
+		{
+			AvatarRecords[AvatarId] = FDateTime::Now().ToUnixTimestamp();
+		}
+		Save();
+	}
+	const FString JsonStr = FAvatarStorage::LoadJson(ManifestFilename);
+	if (!JsonStr.IsEmpty())
+	{
+		AvatarRecords = FAvatarManifestExtractor::ExtractAvatarManifest(JsonStr);
+	}
+	bIsManifestLoaded = true;
+}
+
+void FAvatarManifest::Save() const
+{
+	FAvatarStorage::SaveJson(FAvatarStorage::GetManifestFilePath(), FAvatarManifestExtractor::SerializeAvatarManifest(AvatarRecords));
+}
+
+TArray<FString> FAvatarManifest::GetIdsByOldestDate()
+{
+	AvatarRecords.ValueSort(TGreater<int64>());
+	TArray<FString> SortedIds;
+	AvatarRecords.GetKeys(SortedIds);
+	for (const FString& BlockedAvatar : BlockedAvatars)
+	{
+		SortedIds.Remove(BlockedAvatar);
+	}
+	return SortedIds;
+}
+
+void FAvatarManifest::EnforceAvatarLimit()
+{
+	const UReadyPlayerMeSettings* Settings = GetDefault<UReadyPlayerMeSettings>();
+	if (!bIsManifestLoaded)
+	{
+		Load();
+	}
+	int32 CurrentAvatarCount = AvatarRecords.Num();
+	if (CurrentAvatarCount <= Settings->CachedAvatarLimit)
+	{
+		return;
+	}
+	TArray<FString> AvatarQueue = GetIdsByOldestDate();
+	while (CurrentAvatarCount > Settings->CachedAvatarLimit && AvatarQueue.Num() != 0)
+	{
+		const FString AvatarId = AvatarQueue.Pop();
+		FAvatarStorage::ClearAvatar(AvatarId);
+		AvatarRecords.Remove(AvatarId);
+		CurrentAvatarCount--;
+	}
+	Save();
+}

--- a/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.cpp
+++ b/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.cpp
@@ -21,10 +21,10 @@ void FAvatarManifest::AddAvatar(const FString& AvatarId)
 	}
 }
 
-void FAvatarManifest::BlockAvatar(const FString& AvatarId)
+void FAvatarManifest::LockAvatar(const FString& AvatarId)
 {
 	Load();
-	BlockedAvatars.Add(AvatarId);
+	LockedAvatars.Add(AvatarId);
 	if (AvatarRecords.Contains(AvatarId))
 	{
 		AvatarRecords[AvatarId] = FDateTime::Now().ToUnixTimestamp();
@@ -32,9 +32,9 @@ void FAvatarManifest::BlockAvatar(const FString& AvatarId)
 	}
 }
 
-void FAvatarManifest::UnblockAvatar(const FString& AvatarId)
+void FAvatarManifest::UnlockAvatar(const FString& AvatarId)
 {
-	BlockedAvatars.Remove(AvatarId);
+	LockedAvatars.Remove(AvatarId);
 }
 
 void FAvatarManifest::ClearAvatar(const FString& AvatarId)
@@ -85,7 +85,7 @@ TArray<FString> FAvatarManifest::GetIdsByOldestDate()
 	AvatarRecords.ValueSort(TGreater<int64>());
 	TArray<FString> SortedIds;
 	AvatarRecords.GetKeys(SortedIds);
-	for (const FString& BlockedAvatar : BlockedAvatars)
+	for (const FString& BlockedAvatar : LockedAvatars)
 	{
 		SortedIds.Remove(BlockedAvatar);
 	}

--- a/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.cpp
+++ b/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.cpp
@@ -37,7 +37,7 @@ void FAvatarManifest::UnblockAvatar(const FString& AvatarId)
 	BlockedAvatars.Remove(AvatarId);
 }
 
-void FAvatarManifest::RemoveAvatar(const FString& AvatarId)
+void FAvatarManifest::ClearAvatar(const FString& AvatarId)
 {
 	Load();
 	AvatarRecords.Remove(AvatarId);

--- a/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.h
+++ b/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.h
@@ -1,0 +1,25 @@
+// Copyright © 2021++ Ready Player Me
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FAvatarManifest
+{
+public:
+	void AddAvatar(const FString& AvatarId);
+	void RemoveAvatar(const FString& AvatarId);
+	void BlockAvatar(const FString& AvatarId);
+	void UnblockAvatar(const FString& AvatarId);
+	void Clear();
+
+private:
+	void EnforceAvatarLimit();
+	TArray<FString> GetIdsByOldestDate();
+	void Save() const;
+	void Load();
+	
+	TMap<FString, int64> AvatarRecords;
+	TSet<FString> BlockedAvatars;
+	bool bIsManifestLoaded = false;
+};

--- a/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.h
+++ b/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.h
@@ -7,6 +7,7 @@
 class FAvatarManifest
 {
 public:
+	void AddAvatarAndEnforceLimit(const FString& AvatarId);
 	void AddAvatar(const FString& AvatarId);
 	void RemoveAvatar(const FString& AvatarId);
 	void BlockAvatar(const FString& AvatarId);

--- a/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.h
+++ b/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.h
@@ -9,7 +9,7 @@ class FAvatarManifest
 public:
 	void AddAvatarAndEnforceLimit(const FString& AvatarId);
 	void AddAvatar(const FString& AvatarId);
-	void RemoveAvatar(const FString& AvatarId);
+	void ClearAvatar(const FString& AvatarId);
 	void BlockAvatar(const FString& AvatarId);
 	void UnblockAvatar(const FString& AvatarId);
 	void Clear();

--- a/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.h
+++ b/Source/ReadyPlayerMe/Private/Storage/AvatarManifest.h
@@ -10,8 +10,8 @@ public:
 	void AddAvatarAndEnforceLimit(const FString& AvatarId);
 	void AddAvatar(const FString& AvatarId);
 	void ClearAvatar(const FString& AvatarId);
-	void BlockAvatar(const FString& AvatarId);
-	void UnblockAvatar(const FString& AvatarId);
+	void LockAvatar(const FString& AvatarId);
+	void UnlockAvatar(const FString& AvatarId);
 	void Clear();
 
 private:
@@ -21,6 +21,6 @@ private:
 	void Load();
 	
 	TMap<FString, int64> AvatarRecords;
-	TSet<FString> BlockedAvatars;
+	TSet<FString> LockedAvatars;
 	bool bIsManifestLoaded = false;
 };

--- a/Source/ReadyPlayerMe/Private/Storage/AvatarStorage.h
+++ b/Source/ReadyPlayerMe/Private/Storage/AvatarStorage.h
@@ -9,18 +9,16 @@ class FAvatarStorage
 {
 public:
 	static void SaveAvatar(const FString& GlbFilePath, const TArray<uint8>& Data);
-	static void SaveMetadata(const FString& MetadataFilePath, const FString& Content);
+	static void SaveJson(const FString& Path, const FString& Content);
 	
 	static bool AvatarExists(const FAvatarUri& AvatarUri);
 	static bool FileExists(const FString& Path);
-	static FString LoadMetadata(const FString& Path);
+	static FString LoadJson(const FString& Path);
 	static void ClearCache();
 	static void DeleteDirectory(const FString& Path);
 	static bool IsCacheEmpty();
 	static void ClearAvatar(const FString& Guid);
-	static int32 GetAvatarCount();
+	static TArray<FString> GetSavedAvatars();
 	static int64 GetCacheSize();
-
-private:
-	static bool CheckAndRemoveExistingFile(const FString& FilePath);
+	static FString GetManifestFilePath();
 };

--- a/Source/ReadyPlayerMe/Private/Utils/AvatarManifestExtractor.cpp
+++ b/Source/ReadyPlayerMe/Private/Utils/AvatarManifestExtractor.cpp
@@ -1,0 +1,58 @@
+// Copyright © 2021++ Ready Player Me
+
+
+#include "AvatarManifestExtractor.h"
+
+#include "ReadyPlayerMeTypes.h"
+
+static const FString JSON_AVATAR_RECORDS = "AvatarRecords";
+static const FString JSON_ID = "id";
+static const FString JSON_USED_TS = "UsedTs";
+
+TMap<FString, int64> FAvatarManifestExtractor::ExtractAvatarManifest(const FString& JsonString)
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject->HasField(JSON_AVATAR_RECORDS))
+	{
+		return {};
+	}
+
+	TMap<FString, int64> AvatarRecords;
+	const TArray<TSharedPtr<FJsonValue>> RecordsJson = JsonObject->GetArrayField(JSON_AVATAR_RECORDS);
+	for (const auto& JsonValue : RecordsJson)
+	{
+		const auto JsonValueObject = JsonValue->AsObject();
+		if (JsonValueObject->HasTypedField<EJson::String>(JSON_ID) && JsonValueObject->HasTypedField<EJson::Number>(JSON_USED_TS))
+		{
+			const FString AvatarId = JsonValueObject->GetStringField(JSON_ID);
+			const int64 UpdatedTimestamp = JsonValueObject->GetNumberField(JSON_USED_TS);
+			AvatarRecords.Add(AvatarId, UpdatedTimestamp);
+		}
+	}
+
+	return AvatarRecords;
+}
+
+FString FAvatarManifestExtractor::SerializeAvatarManifest(const TMap<FString, int64>& AvatarRecords)
+{
+	FString OutputJsonString;
+
+	const TSharedPtr<FJsonObject> JsonObject = MakeShared<FJsonObject>();
+
+	TArray<TSharedPtr<FJsonValue>> RecordObjects;
+	for (const auto& AvatarRecord: AvatarRecords)
+	{
+		const TSharedPtr<FJsonObject> RecordJson = MakeShared<FJsonObject>();
+		RecordJson->SetStringField(JSON_ID, AvatarRecord.Key);
+		RecordJson->SetNumberField(JSON_USED_TS, AvatarRecord.Value);
+		RecordObjects.Add(MakeShared<FJsonValueObject>(RecordJson));
+	}
+	JsonObject->SetArrayField(JSON_AVATAR_RECORDS, RecordObjects);
+
+	if (!FJsonSerializer::Serialize(JsonObject.ToSharedRef(), TJsonWriterFactory<>::Create(&OutputJsonString)))
+	{
+		UE_LOG(LogReadyPlayerMe, Warning, TEXT("Failed to create a valid json"));
+	}
+	return OutputJsonString;
+}

--- a/Source/ReadyPlayerMe/Private/Utils/AvatarManifestExtractor.h
+++ b/Source/ReadyPlayerMe/Private/Utils/AvatarManifestExtractor.h
@@ -1,0 +1,12 @@
+// Copyright © 2021++ Ready Player Me
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FAvatarManifestExtractor
+{
+public:
+	static TMap<FString, int64> ExtractAvatarManifest(const FString& JsonString);
+	static FString SerializeAvatarManifest(const TMap<FString, int64>& AvatarRecords);
+};

--- a/Source/ReadyPlayerMe/Public/ReadyPlayerMeAvatarLoader.h
+++ b/Source/ReadyPlayerMe/Public/ReadyPlayerMeAvatarLoader.h
@@ -12,7 +12,7 @@
  * Responsible for Loading the avatar from the url and storing it in the local storage.
  * ReadyPlayerMeAvatarLoader is used by ReadyPlayerMeComponent for loading the avatar.
  */
-UCLASS(BlueprintType)
+UCLASS(BlueprintType, Meta = (ShowWorldContextPin))
 class READYPLAYERME_API UReadyPlayerMeAvatarLoader : public UObject
 {
 	GENERATED_BODY()
@@ -31,7 +31,7 @@ public:
 	 * @param OnDownloadCompleted Success callback. Called when the avatar asset is downloaded.
 	 * @param OnLoadFailed Failure callback. If the avatar fails to load, the failure callback will be called.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Load Avatar", AutoCreateRefTerm = "OnLoadFailed,SkeletalMeshConfig"))
+	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Load Avatar", AutoCreateRefTerm = "OnLoadFailed,SkeletalMeshConfig", WorldContext = "WorldContextObject"))
 	void LoadAvatar(UPARAM(DisplayName="Url") const FString& UrlShortcode, class UReadyPlayerMeAvatarConfig* AvatarConfig,
 		USkeleton* TargetSkeleton, const FglTFRuntimeSkeletalMeshConfig& SkeletalMeshConfig,
 		const FAvatarDownloadCompleted& OnDownloadCompleted, const FAvatarLoadFailed& OnLoadFailed);

--- a/Source/ReadyPlayerMe/Public/ReadyPlayerMeFunctionLibrary.h
+++ b/Source/ReadyPlayerMe/Public/ReadyPlayerMeFunctionLibrary.h
@@ -16,26 +16,26 @@ class READYPLAYERME_API UReadyPlayerMeFunctionLibrary : public UBlueprintFunctio
 
 public:
 	/** Clears all avatars from the persistent cache. */
-	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Clear Avatar Cache", WorldContext = "WorldContextObject"))
+	UFUNCTION(BlueprintCallable, Category = "Ready Player Me | Avatar Caching", meta = (DisplayName = "Clear Avatar Cache", WorldContext = "WorldContextObject"))
 	static void ClearAvatarCache(const UObject* WorldContextObject);
 
 	/** Clears a specific avatar from persistent cache. */
-	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Clear Avatar", WorldContext = "WorldContextObject"))
-	static void ClearAvatar(const UObject* WorldContextObject, const FString& AvatarId);
+	UFUNCTION(BlueprintCallable, Category = "Ready Player Me | Avatar Caching", meta = (DisplayName = "Clear Avatar From Cache", WorldContext = "WorldContextObject"))
+	static void ClearAvatarFromCache(const UObject* WorldContextObject, const FString& AvatarId);
 
 	/** Is there any avatars present in the persistent cache. */
-	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Is Avatar Cache Empty"))
+	UFUNCTION(BlueprintCallable, Category = "Ready Player Me | Avatar Caching", meta = (DisplayName = "Is Avatar Cache Empty"))
 	static bool IsAvatarCacheEmpty();
 
 	/** Total Avatars stored in persistent cache. */
-	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Get Avatar Count"))
-	static int32 GetAvatarCount();
+	UFUNCTION(BlueprintPure, Category = "Ready Player Me | Avatar Caching", meta = (DisplayName = "Get Cached Avatar Count"))
+	static int32 GetCachedAvatarCount();
 
 	/** Total Avatars stored in persistent cache. */
-	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Get Cache Size"))
-	static int64 GetCacheSize();
+	UFUNCTION(BlueprintPure, Category = "Ready Player Me | Avatar Caching", meta = (DisplayName = "Get Avatar Cache Size"))
+	static int64 GetAvatarCacheSize();
 
 	/** Get unique id of the avatar. */
-	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Get Avatar Id"))
+	UFUNCTION(BlueprintPure, Category = "Ready Player Me", meta = (DisplayName = "Get Avatar Id"))
 	static FString GetAvatarId(const FString& Url);
 };

--- a/Source/ReadyPlayerMe/Public/ReadyPlayerMeFunctionLibrary.h
+++ b/Source/ReadyPlayerMe/Public/ReadyPlayerMeFunctionLibrary.h
@@ -36,6 +36,6 @@ public:
 	static int64 GetCacheSize();
 
 	/** Get unique id of the avatar. */
-	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Get Avatar Guid"))
-	static FString GetAvatarGuid(UPARAM(DisplayName="Url") const FString& UrlShortcode);
+	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Get Avatar Id"))
+	static FString GetAvatarId(const FString& Url);
 };

--- a/Source/ReadyPlayerMe/Public/ReadyPlayerMeFunctionLibrary.h
+++ b/Source/ReadyPlayerMe/Public/ReadyPlayerMeFunctionLibrary.h
@@ -16,12 +16,12 @@ class READYPLAYERME_API UReadyPlayerMeFunctionLibrary : public UBlueprintFunctio
 
 public:
 	/** Clears all avatars from the persistent cache. */
-	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Clear Avatar Cache"))
-	static void ClearAvatarCache();
+	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Clear Avatar Cache", WorldContext = "WorldContextObject"))
+	static void ClearAvatarCache(const UObject* WorldContextObject);
 
 	/** Clears a specific avatar from persistent cache. */
-	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Clear Avatar"))
-	static void ClearAvatar(const FString& Guid);
+	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Clear Avatar", WorldContext = "WorldContextObject"))
+	static void ClearAvatar(const UObject* WorldContextObject, const FString& AvatarId);
 
 	/** Is there any avatars present in the persistent cache. */
 	UFUNCTION(BlueprintCallable, Category = "Ready Player Me", meta = (DisplayName = "Is Avatar Cache Empty"))

--- a/Source/ReadyPlayerMe/Public/ReadyPlayerMeGameSubsystem.h
+++ b/Source/ReadyPlayerMe/Public/ReadyPlayerMeGameSubsystem.h
@@ -19,4 +19,6 @@ public:
 
 	UPROPERTY(BlueprintReadOnly, Category="Ready Player Me")
 	class UReadyPlayerMeMemoryCache* MemoryCache;
+
+	TSharedPtr<class FAvatarManifest> AvatarManifest;
 };

--- a/Source/ReadyPlayerMe/Public/ReadyPlayerMeSettings.h
+++ b/Source/ReadyPlayerMe/Public/ReadyPlayerMeSettings.h
@@ -31,6 +31,10 @@ public:
 		ToolTip = "If checked, the loaded avatars will be saved in the local storage."))
 	bool bEnableAvatarCaching;
 
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Settings", meta = (DisplayName = "Cached Avatar Limit",
+				ToolTip = "The limit of the cached avatars, when the milit is exceeded the old avatars will automatically be cleaned."))
+	int32 CachedAvatarLimit;
+
 	static void SetAvatarCaching(bool bEnableCaching);
 
 #if WITH_EDITOR

--- a/Source/ReadyPlayerMe/Public/ReadyPlayerMeSettings.h
+++ b/Source/ReadyPlayerMe/Public/ReadyPlayerMeSettings.h
@@ -11,6 +11,24 @@
 DECLARE_DELEGATE_OneParam(FEditorSettingsChanged, const FName&);
 #endif
 
+USTRUCT()
+struct READYPLAYERME_API FRpmAvatarCacheSettings
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, Category = "Avatar Caching", meta = (DisplayName = "Enable Avatar Caching",
+	ToolTip = "If checked, the loaded avatars will be saved in the local storage."))
+	bool bEnableAvatarCaching = false;
+
+	UPROPERTY(EditAnywhere, Category = "Avatar Caching | Automated Cleanup", meta = (DisplayName = "Enable Automatic Avatar Cache Cleaning",
+		ToolTip = "If checked, the old avatars will be automatically removed if the number of the saved aavatars exceeds the cached avatar limit."))
+	bool bEnableAutomaticCacheCleaning = false;
+
+	UPROPERTY(EditAnywhere, Category = "Avatar Caching | Automated Cleanup", meta = (DisplayName = "Cached Avatar Limit",
+				ToolTip = "The limit of the cached avatars, when the limit is exceeded and the automatic cleaning is enabled the old avatars will automatically be cleaned."))
+	int32 CachedAvatarLimit = 50;
+};
+
 UCLASS(config=Game, defaultconfig, meta = (DisplayName="Ready Player Me"))
 class READYPLAYERME_API UReadyPlayerMeSettings : public UDeveloperSettings
 {
@@ -27,13 +45,9 @@ public:
 	ToolTip = "The Subdomain is used to identify your application. You can find it in the Ready Player Me application dashboard in studio https://studio.readyplayer.me/applications."))
 	FString Subdomain;
 
-	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Settings", meta = (DisplayName = "Enable Avatar Caching",
-		ToolTip = "If checked, the loaded avatars will be saved in the local storage."))
-	bool bEnableAvatarCaching;
-
-	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Settings", meta = (DisplayName = "Cached Avatar Limit",
-				ToolTip = "The limit of the cached avatars, when the milit is exceeded the old avatars will automatically be cleaned."))
-	int32 CachedAvatarLimit;
+	UPROPERTY(Config, EditAnywhere, Category = "Settings", meta = (DisplayName = "Avatar Cache Settings",
+	ToolTip = "Settings for saving the avatars in the local storage."))
+	FRpmAvatarCacheSettings AvatarCacheSettings;
 
 	static void SetAvatarCaching(bool bEnableCaching);
 

--- a/Source/ReadyPlayerMeEditor/Private/Analytics/AnalyticsSetup.cpp
+++ b/Source/ReadyPlayerMeEditor/Private/Analytics/AnalyticsSetup.cpp
@@ -16,7 +16,7 @@ namespace
 	{
 		if (PropertyName == SETTINGS_ENABLE_CACHING)
 		{
-			FAnalyticsEventLogger::Get().LogEnableAvatarCaching(Settings->bEnableAvatarCaching);
+			FAnalyticsEventLogger::Get().LogEnableAvatarCaching(Settings->AvatarCacheSettings.bEnableAvatarCaching);
 		}
 	}
 }


### PR DESCRIPTION
## [SDK-372](https://ready-player-me.atlassian.net/browse/SDK-372)

## Description

-   Added AvatarManifest for saving the avatars load time
-   Changed AvatarCacheHandler to support the manifest

## Changes

#### Added

-   Added AvatarManifest for saving the avatars load time

#### Updated

-   Changed AvatarCacheHandler to support the manifest

## How to Test

-   Change the AvatarLimit in the project settings and check if the old avatars are removed when the new ones are added

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.


[SDK-372]: https://ready-player-me.atlassian.net/browse/SDK-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ