### PR TITLE
Added avatar template filter by body type

### DIFF
--- a/Source/RpmAvatarCreator/Private/Downloaders/RpmAvatarTemplateDownloader.cpp
+++ b/Source/RpmAvatarCreator/Private/Downloaders/RpmAvatarTemplateDownloader.cpp
@@ -1,13 +1,11 @@
 // Copyright © 2023++ Ready Player Me
 
-
 #include "RpmAvatarTemplateDownloader.h"
-
 #include "Requests/RequestFactory.h"
 #include "Extractors/AvatarTemplateExtractor.h"
 
-FRpmAvatarTemplateDownloader::FRpmAvatarTemplateDownloader(TSharedPtr<class FRequestFactory> Factory)
-	: RequestFactory(Factory)
+FRpmAvatarTemplateDownloader::FRpmAvatarTemplateDownloader(TSharedPtr<class FRequestFactory> Factory,
+	const EAvatarBodyType& BodyType) : RequestFactory(Factory), AvatarBodyType(BodyType)
 {
 }
 
@@ -20,7 +18,7 @@ void FRpmAvatarTemplateDownloader::DownloadTemplates(const FAvatarTemplatesDownl
 	}
 	OnDownloadCompleted = DownloadCompleted;
 	OnFailed = Failed;
-	AvatarTemplatesRequest = RequestFactory->CreateAvatarTemplatesRequest();
+	AvatarTemplatesRequest = RequestFactory->CreateAvatarTemplatesRequest(AvatarBodyType);
 	AvatarTemplatesRequest->GetCompleteCallback().BindSP(AsShared(), &FRpmAvatarTemplateDownloader::OnTemplatesDownloadCompleted);
 	AvatarTemplatesRequest->Download();
 }

--- a/Source/RpmAvatarCreator/Private/Downloaders/RpmAvatarTemplateDownloader.h
+++ b/Source/RpmAvatarCreator/Private/Downloaders/RpmAvatarTemplateDownloader.h
@@ -8,7 +8,7 @@
 class FRpmAvatarTemplateDownloader : public TSharedFromThis<FRpmAvatarTemplateDownloader>
 {
 public:
-	FRpmAvatarTemplateDownloader(TSharedPtr<class FRequestFactory> Factory);
+	FRpmAvatarTemplateDownloader(TSharedPtr<class FRequestFactory> Factory, const EAvatarBodyType& BodyType);
 
 	void DownloadTemplates(const FAvatarTemplatesDownloadCompleted& DownloadCompleted, const FAvatarCreatorFailed& Failed);
 	TArray<FRpmAvatarTemplate> GetAvatarTemplates() const;
@@ -22,4 +22,5 @@ private:
 	TSharedPtr<class FRequestFactory> RequestFactory;
 	TArray<FRpmAvatarTemplate> AvatarTemplates;
 	TSharedPtr<class IBaseRequest> AvatarTemplatesRequest;
+	EAvatarBodyType AvatarBodyType;
 };

--- a/Source/RpmAvatarCreator/Private/Requests/Endpoints.cpp
+++ b/Source/RpmAvatarCreator/Private/Requests/Endpoints.cpp
@@ -2,6 +2,7 @@
 
 
 #include "Endpoints.h"
+#include "RpmAvatarCreatorTypes.h"
 
 static const TCHAR* API_ENDPOINT = TEXT("https://{0}.readyplayer.me/api{1}");
 static const TCHAR* AVATAR_API_V2_ENDPOINT = TEXT("https://api.readyplayer.me/v2/avatars");
@@ -65,9 +66,24 @@ FString FEndpoints::GetCreateEndpoint()
 	return AVATAR_API_V2_ENDPOINT;
 }
 
-FString FEndpoints::GetAvatarTemplatesEndpoint(const FString& TemplateId)
+FString FEndpoints::GetCreateFromTemplateEndpoint(const FString& TemplateId)
 {
 	return FString::Format(TEXT("{0}/{1}/{2}"), {AVATAR_API_V2_ENDPOINT, TEXT("templates"), TemplateId});
+}
+
+FString FEndpoints::GetAvatarTemplatesByType(const EAvatarBodyType& BodyType)
+{
+	// Define the static map
+	static const TMap<EAvatarBodyType, FString> EnumToStringMap = {
+		{EAvatarBodyType::Undefined, TEXT("")},
+		{EAvatarBodyType::FullBody, TEXT("fullbody")},
+		{EAvatarBodyType::HalfBody, TEXT("halfbody")}
+	};
+
+	// Find the string associated with the enum
+	const FString* StringValue = EnumToStringMap.Find(BodyType);
+	
+	return FString::Format(TEXT("{0}/{1}?bodyType={2}"), {AVATAR_API_V2_ENDPOINT, TEXT("templates"), *StringValue});
 }
 
 FString FEndpoints::GetAvatarModelEndpoint(const FString& AvatarId, bool bIsPreview)

--- a/Source/RpmAvatarCreator/Private/Requests/Endpoints.h
+++ b/Source/RpmAvatarCreator/Private/Requests/Endpoints.h
@@ -4,6 +4,9 @@
 
 #include "CoreMinimal.h"
 
+enum class EAvatarBodyType : uint8;
+enum class ERpmAvatarTemplateType : uint8;
+
 class FEndpoints
 {
 public:
@@ -15,7 +18,9 @@ public:
 
 	static FString GetTokenRefreshEndpoint(const FString& Subdomain);
 
-	static FString GetAvatarTemplatesEndpoint(const FString& TemplateId = "");
+	static FString GetCreateFromTemplateEndpoint(const FString& TemplateId = "");
+	
+	static FString GetAvatarTemplatesByType(const EAvatarBodyType& BodyType);
 
 	static FString GetAssetEndpoint(const FString& AssetTypeStr, int32 Limit, int32 Page, const FString& UserId, const FString& AppId);
 

--- a/Source/RpmAvatarCreator/Private/Requests/RequestFactory.cpp
+++ b/Source/RpmAvatarCreator/Private/Requests/RequestFactory.cpp
@@ -75,9 +75,9 @@ TSharedPtr<IBaseRequest> FRequestFactory::CreateAuthAnonymousRequest() const
 	return CreateBaseRequest(FEndpoints::GetAuthAnonymousEndpoint(Subdomain), ERequestVerb::Post);
 }
 
-TSharedPtr<IBaseRequest> FRequestFactory::CreateAvatarTemplatesRequest() const
+TSharedPtr<IBaseRequest> FRequestFactory::CreateAvatarTemplatesRequest(const EAvatarBodyType& BodyType) const
 {
-	return CreateAuthorizedRequest(FEndpoints::GetAvatarTemplatesEndpoint());
+	return CreateAuthorizedRequest(FEndpoints::GetAvatarTemplatesByType(BodyType));
 }
 
 TSharedPtr<IBaseRequest> FRequestFactory::CreateAssetRequest(const FString& AssetTypeStr, int32 Limit, int32 Page) const
@@ -121,7 +121,7 @@ TSharedPtr<IBaseRequest> FRequestFactory::CreateAvatarCreateRequest(const FStrin
 	{
 		return CreateAuthorizedRequest(FEndpoints::GetCreateEndpoint(), ERequestVerb::Post, PayloadJson);
 	}
-	return CreateAuthorizedRequest(FEndpoints::GetAvatarTemplatesEndpoint(TemplateId), ERequestVerb::Post, PayloadJson);
+	return CreateAuthorizedRequest(FEndpoints::GetCreateFromTemplateEndpoint(TemplateId), ERequestVerb::Post, PayloadJson);
 }
 
 TSharedPtr<IBaseRequest> FRequestFactory::CreateUpdateAvatarRequest(const FString& AvatarId, const FString& PayloadJson) const

--- a/Source/RpmAvatarCreator/Private/Requests/RequestFactory.h
+++ b/Source/RpmAvatarCreator/Private/Requests/RequestFactory.h
@@ -34,7 +34,7 @@ public:
 	TSharedPtr<IBaseRequest> CreateColorRequest(const FString& AvatarId) const;
 	TSharedPtr<IBaseRequest> CreateAvatarModelRequest(const FString& AvatarId, bool bIsPreview) const;
 	TSharedPtr<IBaseRequest> CreateAvatarMetadataRequest(const FString& AvatarId) const;
-	TSharedPtr<IBaseRequest> CreateAvatarTemplatesRequest() const;
+	TSharedPtr<IBaseRequest> CreateAvatarTemplatesRequest(const EAvatarBodyType& BodyType) const;
 	TSharedPtr<IBaseRequest> CreateAvatarCreateRequest(const FString& PayloadJson, const FString& TemplateId) const;
 	TSharedPtr<IBaseRequest> CreateImageRequest(const FString& IconUrl) const;
 	TSharedPtr<IBaseRequest> CreateRenderRequest(const FString& AvatarId) const;

--- a/Source/RpmAvatarCreator/Private/RpmAvatarCreatorApi.cpp
+++ b/Source/RpmAvatarCreator/Private/RpmAvatarCreatorApi.cpp
@@ -29,7 +29,7 @@ void URpmAvatarCreatorApi::Initialize()
 	AuthManager->BindTokenRefreshDelegate();
 	ColorDownloader = MakeShared<FRpmColorDownloader>(RequestFactory);
 	AssetDownloader = MakeShared<FRpmPartnerAssetDownloader>(RequestFactory, BodyType);
-	AvatarTemplateDownloader = MakeShared<FRpmAvatarTemplateDownloader>(RequestFactory);
+	AvatarTemplateDownloader = MakeShared<FRpmAvatarTemplateDownloader>(RequestFactory, BodyType);
 	UserAvatarDownloader = MakeShared<FRpmUserAvatarDownloader>(RequestFactory);
 	ImageDownloader = NewObject<URpmImageDownloader>();
 	ImageDownloader->SetRequestFactory(RequestFactory);

--- a/Source/RpmAvatarCreator/Public/RpmAvatarCreatorFunctionLibrary.h
+++ b/Source/RpmAvatarCreator/Public/RpmAvatarCreatorFunctionLibrary.h
@@ -26,4 +26,6 @@ public:
 	/** Get skeletal mesh from the skeletal mesh component. */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Ready Player Me", meta = (DisplayName = "Get Skeletal Mesh From Component"))
 	static class USkeletalMesh* GetSkeletalMeshFromComponent(const class USkeletalMeshComponent* Component);
+
+	
 };


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Monday and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [TICKETID](https://ready-player-me.atlassian.net/browse/TICKETID)

## Description

-   This PR updates avatar template endpoint to allow filtering by bodytype to enable fetching only relevant templates

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-    run the CAC and test that correct avatar templates are fetched

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.

## QA Testing

-   Mention any useful test cases for this feature and add to QA Testing documentation.

## Details

-   If more details are necessary to support the description with images and videos add them here.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



